### PR TITLE
optimize Array.of and Array.from for cpu pipelining and branch predic…

### DIFF
--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -27,12 +27,30 @@ function of(/* items... */)
 {
     "use strict";
 
-    var length = @argumentCount();
-    var array = this !== @Array && @isConstructor(this) ? new this(length) : @newArrayWithSize(length);
-    for (var k = 0; k < length; ++k)
-        @putByValDirect(array, k, arguments[k]);
-    array.length = length;
-    return array;
+    // !bun patch
+    const len = @argumentCount();
+    const extended = this !== @Array && @isConstructor(this);
+    const arr = extended ? new this(len) : @newArrayWithSize(len);
+
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, arguments[o]);
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, arguments[o]);
+            @putByValDirect(arr, o + 1, arguments[o + 1]);
+            @putByValDirect(arr, o + 2, arguments[o + 2]);
+            @putByValDirect(arr, o + 3, arguments[o + 3]);
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, arguments[o]);
+    }
+
+    return (arr.length = len, arr);
+    // @bun patch
 }
 
 function from(items /*, mapFn, thisArg */)
@@ -58,53 +76,118 @@ function from(items /*, mapFn, thisArg */)
             return fastResult;
     }
 
-    var iteratorMethod = items.@@iterator;
+    // !bun patch
+    const iteratorMethod = items.@@iterator;
+
     if (!@isUndefinedOrNull(iteratorMethod)) {
         if (!@isCallable(iteratorMethod))
             @throwTypeError("Array.from requires that the property of the first argument, items[Symbol.iterator], when exists, be a function");
 
-        var result = this !== @Array && @isConstructor(this) ? new this() : [];
+        const extended = this !== @Array && @isConstructor(this);
 
-        var k = 0;
-        var iterator = iteratorMethod.@call(items);
+        let offset = 0;
+        const arr = extended ? new this() : [];
+        const iterator = iteratorMethod.@call(items);
 
-        // Since for-of loop once more looks up the @@iterator property of a given iterable,
-        // it could be observable if the user defines a getter for @@iterator.
-        // To avoid this situation, we define a wrapper object that @@iterator just returns a given iterator.
-        var wrapper = {
+        const wrapper = {
             @@iterator: function () { return iterator; }
         };
 
-        for (var value of wrapper) {
-            if (k >= @MAX_SAFE_INTEGER)
-                @throwTypeError("Length exceeded the maximum array length");
-            if (mapFn === @undefined)
-                @putByValDirect(result, k, value);
-            else
-                @putByValDirect(result, k, thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k));
-            k += 1;
+        if (mapFn === @undefined) {
+            for (const value of wrapper) {
+                if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+                @putByValDirect(arr, offset, value);
+
+                offset++;
+            }
         }
 
-        result.length = k;
-        return result;
+        else {
+            if (thisArg === @undefined) {
+                for (const value of wrapper) {
+                    if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+                    @putByValDirect(arr, offset, mapFn(value, offset));
+
+                    offset++;
+                }
+            }
+
+            else {
+                for (const value of wrapper) {
+                    if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+                    @putByValDirect(arr, offset, mapFn.@call(thisArg, value, offset));
+
+                    offset++;
+                }
+            }
+        }
+
+        return (arr.length = offset, arr);
+    }
+    // @bun patch
+
+    // !bun patch
+    const len = @toLength(arrayLike.length);
+    const extended = this !== @Array && @isConstructor(this);
+    const arr = extended ? new this(len) : @newArrayWithSize(len);
+    
+    const unrollable = len <= 2 ** 30;
+
+    if (mapFn === @undefined) {
+        if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+
+        else {
+            const unrolled = len & ~3;
+
+            for (let o = 0; o < unrolled; o += 4) {
+                @putByValDirect(arr, o, arrayLike[o]);
+                @putByValDirect(arr, o + 1, arrayLike[o + 1]);
+                @putByValDirect(arr, o + 2, arrayLike[o + 2]);
+                @putByValDirect(arr, o + 3, arrayLike[o + 3]);
+            }
+
+            for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+        }
     }
 
-    var arrayLikeLength = @toLength(arrayLike.length);
+    else {
+        if (thisArg === @undefined) {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
 
-    var result = this !== @Array && @isConstructor(this) ? new this(arrayLikeLength) : @newArrayWithSize(arrayLikeLength);
+            else {
+                const unrolled = len & ~3;
 
-    var k = 0;
-    while (k < arrayLikeLength) {
-        var value = arrayLike[k];
-        if (mapFn === @undefined)
-            @putByValDirect(result, k, value);
-        else
-            @putByValDirect(result, k, thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k));
-        k += 1;
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, mapFn(arrayLike[o], o));
+                    @putByValDirect(arr, o + 1, mapFn(arrayLike[o + 1], o + 1));
+                    @putByValDirect(arr, o + 2, mapFn(arrayLike[o + 2], o + 2));
+                    @putByValDirect(arr, o + 3, mapFn(arrayLike[o + 3], o + 3));
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
+            }
+        }
+
+        else {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
+
+            else {
+                const unrolled = len & ~3;
+
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
+                    @putByValDirect(arr, o + 1, mapFn.@call(thisArg, arrayLike[o + 1], o + 1));
+                    @putByValDirect(arr, o + 2, mapFn.@call(thisArg, arrayLike[o + 2], o + 2));
+                    @putByValDirect(arr, o + 3, mapFn.@call(thisArg, arrayLike[o + 3], o + 3));
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
+            }
+        }
     }
 
-    result.length = arrayLikeLength;
-    return result;
+    return (arr.length = len, arr);
+    // @bun patch
 }
 
 function isArray(array)
@@ -124,29 +207,46 @@ async function defaultAsyncFromAsyncIterator(iterator, mapFn, thisArg)
 {
     "use strict";
 
-    var result = this !== @Array && @isConstructor(this) ? new this() : [];
+    // !bun patch
+    const extended = this !== @Array && @isConstructor(this);
 
-    var k = 0;
+    let offset = 0;
+    const arr = extended ? new this() : [];
 
-    // Since for-of loop once more looks up the @@iterator property of a given iterable,
-    // it could be observable if the user defines a getter for @@iterator.
-    // To avoid this situation, we define a wrapper object that @@iterator just returns a given iterator.
-    var wrapper = {
+    const wrapper = {
         @@asyncIterator: function () { return iterator; }
     };
 
-    for await (var value of wrapper) {
-        if (k >= @MAX_SAFE_INTEGER)
-            @throwTypeError("Length exceeded the maximum array length");
-        if (mapFn === @undefined)
-            @putByValDirect(result, k, value);
-        else
-            @putByValDirect(result, k, await (thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k)));
-        k += 1;
+    if (mapFn === @undefined) {
+        for await (const value of wrapper) {
+            if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+            @putByValDirect(arr, offset, value);
+
+            offset++;
+        }
     }
 
-    result.length = k;
-    return result;
+    else {
+        if (thisArg === @undefined) {
+            for await (const value of wrapper) {
+                if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+                @putByValDirect(arr, offset, await mapFn(value, offset));
+
+                offset++;
+            }
+        }
+
+        else {
+            for await (const value of wrapper) {
+                if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+                @putByValDirect(arr, offset, await mapFn.@call(thisArg, value, offset));
+
+                offset++;
+            }
+        }
+    }
+
+    return (arr.length = offset, arr);
 }
 
 @linkTimeConstant
@@ -157,22 +257,68 @@ async function defaultAsyncFromAsyncArrayLike(asyncItems, mapFn, thisArg)
 
     var arrayLike = @toObject(asyncItems, "Array.fromAsync requires an array-like object - not null or undefined");
 
-    var arrayLikeLength = @toLength(arrayLike.length);
+    // !bun patch
+    const len = @toLength(arrayLike.length);
+    const extended = this !== @Array && @isConstructor(this);
+    const arr = extended ? new this(len) : @newArrayWithSize(len);
 
-    var result = this !== @Array && @isConstructor(this) ? new this(arrayLikeLength) : @newArrayWithSize(arrayLikeLength);
+    const unrollable = len <= 2 ** 30;
 
-    var k = 0;
-    while (k < arrayLikeLength) {
-        var value = await arrayLike[k];
-        if (mapFn === @undefined)
-            @putByValDirect(result, k, value);
-        else
-            @putByValDirect(result, k, await (thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k)));
-        k += 1;
+    if (mapFn === @undefined) {
+        if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
+
+        else {
+            const unrolled = len & ~3;
+
+            for (let o = 0; o < unrolled; o += 4) {
+                @putByValDirect(arr, o, await arrayLike[o]);
+                @putByValDirect(arr, o + 1, await arrayLike[o + 1]);
+                @putByValDirect(arr, o + 2, await arrayLike[o + 2]);
+                @putByValDirect(arr, o + 3, await arrayLike[o + 3]);
+            }
+
+            for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
+        }
     }
 
-    result.length = arrayLikeLength;
-    return result;
+    else {
+        if (thisArg === @undefined) {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
+
+            else {
+                const unrolled = len & ~3;
+
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
+                    @putByValDirect(arr, o + 1, await mapFn(await arrayLike[o + 1], o + 1));
+                    @putByValDirect(arr, o + 2, await mapFn(await arrayLike[o + 2], o + 2));
+                    @putByValDirect(arr, o + 3, await mapFn(await arrayLike[o + 3], o + 3));
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
+            }
+        }
+
+        else {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+   
+            else {
+                const unrolled = len & ~3;
+   
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+                    @putByValDirect(arr, o + 1, await mapFn.@call(thisArg, await arrayLike[o + 1], o + 1));
+                    @putByValDirect(arr, o + 2, await mapFn.@call(thisArg, await arrayLike[o + 2], o + 2));
+                    @putByValDirect(arr, o + 3, await mapFn.@call(thisArg, await arrayLike[o + 3], o + 3));
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+            }
+        }
+    }
+
+    return (arr.length = len, arr);
+    // @bun patch
 }
 
 function fromAsync(asyncItems  /*, mapFn, thisArg */)

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -27,7 +27,7 @@ function of(/* items... */)
 {
     "use strict";
 
-    // !bun patch
+    
     const len = @argumentCount();
     const extended = this !== @Array && @isConstructor(this);
     const arr = extended ? new this(len) : @newArrayWithSize(len);
@@ -50,7 +50,7 @@ function of(/* items... */)
     }
 
     return (arr.length = len, arr);
-    // @bun patch
+    
 }
 
 function from(items /*, mapFn, thisArg */)
@@ -76,193 +76,242 @@ function from(items /*, mapFn, thisArg */)
             return fastResult;
     }
 
-    // !bun patch
     const iteratorMethod = items.@@iterator;
+    if (!@isUndefinedOrNull(iteratorMethod)) return @bun_arrayFromIterator.@call(this, items, mapFn, thisArg, iteratorMethod);
+    
+    const len = @toLength(arrayLike.length);
+    const fast = @bun_isLengthObject(arrayLike);
+    const extended = this !== @Array && @isConstructor(this);
+    const arr = extended ? new this(len) : @newArrayWithSize(len);
 
-    if (!@isUndefinedOrNull(iteratorMethod)) {
-        if (!@isCallable(iteratorMethod))
-            @throwTypeError("Array.from requires that the property of the first argument, items[Symbol.iterator], when exists, be a function");
+    if (mapFn === @undefined) {
+        if (fast) @bun_arrayFillUndefined(arr, len);
+        else @bun_arrayCopyFrom(arr, len, arrayLike);
+    }
 
-        const extended = this !== @Array && @isConstructor(this);
+    else {
+        if (thisArg === @undefined) {
+            if (fast) @bun_arrayFillMapUndefined(arr, len, mapFn);
+            else @bun_arrayCopyFromMap(arr, len, arrayLike, mapFn);
+        }
 
-        let offset = 0;
-        const arr = extended ? new this() : [];
-        const iterator = iteratorMethod.@call(items);
+        else {
+            if (fast) @bun_arrayFillMapUndefinedThis(arr, len, mapFn, thisArg);
+            else @bun_arrayCopyFromMapThis(arr, len, arrayLike, mapFn, thisArg);
+        }
+    }
 
-        const wrapper = {
-            @@iterator: function () { return iterator; }
-        };
+    return (arr.length = len, arr);
+    
+}
 
-        if (mapFn === @undefined) {
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_isLengthObject(obj) {
+    "use strict";
+
+    if (@isArray(obj)) return false;
+    if (@isProxyObject(obj)) return false;
+    if (@isTypedArrayView(obj)) return false;
+
+    // @isNaturalObject would be useful
+    if (@Object.prototype !== @Object.@getPrototypeOf(obj)) return false;
+
+    // needs @objectAllKeysCount(obj)
+    const keys = @Object.@getOwnPropertyNames(obj);
+    if (1 !== keys.length || keys[0] !== 'length') return false;
+
+    return true;
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayFillUndefined(arr, len) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, @undefined);
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, @undefined);
+            @putByValDirect(arr, o + 1, @undefined);
+            @putByValDirect(arr, o + 2, @undefined);
+            @putByValDirect(arr, o + 3, @undefined);
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, @undefined);
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayCopyFrom(arr, len, src) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, src[o]);
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, src[o]);
+            @putByValDirect(arr, o + 1, src[o + 1]);
+            @putByValDirect(arr, o + 2, src[o + 2]);
+            @putByValDirect(arr, o + 3, src[o + 3]);
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, src[o]);
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayFillMapUndefined(arr, len, map) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, map(@undefined, o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, map(@undefined, o));
+            @putByValDirect(arr, o + 1, map(@undefined, o + 1));
+            @putByValDirect(arr, o + 2, map(@undefined, o + 2));
+            @putByValDirect(arr, o + 3, map(@undefined, o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, map(@undefined, o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayFillMapUndefinedThis(arr, len, map, thisArg) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, map.@call(thisArg, @undefined, o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, map.@call(thisArg, @undefined, o));
+            @putByValDirect(arr, o + 1, map.@call(thisArg, @undefined, o + 1));
+            @putByValDirect(arr, o + 2, map.@call(thisArg, @undefined, o + 2));
+            @putByValDirect(arr, o + 3, map.@call(thisArg, @undefined, o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, map.@call(thisArg, @undefined, o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayCopyFromMap(arr, len, src, map) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, map(src[o], o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, map(src[o], o));
+            @putByValDirect(arr, o + 1, map(src[o + 1], o + 1));
+            @putByValDirect(arr, o + 2, map(src[o + 2], o + 2));
+            @putByValDirect(arr, o + 3, map(src[o + 3], o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, map(src[o], o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayCopyFromMapThis(arr, len, src, map, thisArg) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, map.@call(thisArg, src[o], o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, map.@call(thisArg, src[o], o));
+            @putByValDirect(arr, o + 1, map.@call(thisArg, src[o + 1], o + 1));
+            @putByValDirect(arr, o + 2, map.@call(thisArg, src[o + 2], o + 2));
+            @putByValDirect(arr, o + 3, map.@call(thisArg, src[o + 3], o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, map.@call(thisArg, src[o], o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+function bun_arrayFromIterator(items, mapFn, thisArg, iteratorMethod) {
+    "use strict"
+
+    if (!@isCallable(iteratorMethod))
+        @throwTypeError("Array.from requires that the property of the first argument, items[Symbol.iterator], when exists, be a function");
+
+    const extended = this !== @Array && @isConstructor(this);
+
+    let offset = 0;
+    const arr = extended ? new this() : [];
+    const iterator = iteratorMethod.@call(items);
+
+    const wrapper = {
+        @@iterator: function () { return iterator; }
+    };
+
+    if (mapFn === @undefined) {
+        for (const value of wrapper) {
+            if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+            @putByValDirect(arr, offset, value);
+
+            offset++;
+        }
+    }
+
+    else {
+        if (thisArg === @undefined) {
             for (const value of wrapper) {
                 if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
-                @putByValDirect(arr, offset, value);
+                @putByValDirect(arr, offset, mapFn(value, offset));
 
                 offset++;
             }
         }
 
         else {
-            if (thisArg === @undefined) {
-                for (const value of wrapper) {
-                    if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
-                    @putByValDirect(arr, offset, mapFn(value, offset));
+            for (const value of wrapper) {
+                if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
+                @putByValDirect(arr, offset, mapFn.@call(thisArg, value, offset));
 
-                    offset++;
-                }
-            }
-
-            else {
-                for (const value of wrapper) {
-                    if (offset === @MAX_SAFE_INTEGER) @throwTypeError("Length exceeded the maximum array length");
-                    @putByValDirect(arr, offset, mapFn.@call(thisArg, value, offset));
-
-                    offset++;
-                }
-            }
-        }
-
-        return (arr.length = offset, arr);
-    }
-    // @bun patch
-
-    // !bun patch
-    const len = @toLength(arrayLike.length);
-    const extended = this !== @Array && @isConstructor(this);
-    const arr = extended ? new this(len) : @newArrayWithSize(len);
-
-    let fast = true;
-    const unrollable = len <= 2 ** 30;
-
-    if (@isArray(arrayLike)) fast = false;
-    else if (@isProxyObject(arrayLike)) fast = false;
-    else if (@isTypedArrayView(arrayLike)) fast = false;
-
-    else {
-        // @isNaturalObject would be useful
-        if (@Object.prototype !== @Object.@getPrototypeOf(arrayLike)) fast = false;
-
-        else {
-            // needs @objectAllKeysCount(obj)
-            const keys = @Object.@getOwnPropertyNames(arrayLike);
-            // can hoist === 'length' check with early return on length
-            if (1 !== keys.length || keys[0] !== 'length') fast = false;
-        }
-    }
-
-    if (mapFn === @undefined) {
-        if (fast) {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, @undefined);
-
-            else {
-                const unrolled = len & ~3;
-
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, @undefined);
-                    @putByValDirect(arr, o + 1, @undefined);
-                    @putByValDirect(arr, o + 2, @undefined);
-                    @putByValDirect(arr, o + 3, @undefined);
-                }
-
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, @undefined);
-            }
-        }
-
-        else {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
-
-            else {
-                const unrolled = len & ~3;
-    
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, arrayLike[o]);
-                    @putByValDirect(arr, o + 1, arrayLike[o + 1]);
-                    @putByValDirect(arr, o + 2, arrayLike[o + 2]);
-                    @putByValDirect(arr, o + 3, arrayLike[o + 3]);
-                }
-    
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+                offset++;
             }
         }
     }
 
-    else {
-        if (thisArg === @undefined) {
-            if (fast) {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn(@undefined, o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, mapFn(@undefined, o));
-                        @putByValDirect(arr, o + 1, mapFn(@undefined, o + 1));
-                        @putByValDirect(arr, o + 2, mapFn(@undefined, o + 2));
-                        @putByValDirect(arr, o + 3, mapFn(@undefined, o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn(@undefined, o));
-                }
-            }
-
-            else {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, mapFn(arrayLike[o], o));
-                        @putByValDirect(arr, o + 1, mapFn(arrayLike[o + 1], o + 1));
-                        @putByValDirect(arr, o + 2, mapFn(arrayLike[o + 2], o + 2));
-                        @putByValDirect(arr, o + 3, mapFn(arrayLike[o + 3], o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
-                }
-            }
-        }
-
-        else {
-            if (fast) {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, @undefined, o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, mapFn.@call(thisArg, @undefined, o));
-                        @putByValDirect(arr, o + 1, mapFn.@call(thisArg, @undefined, o + 1));
-                        @putByValDirect(arr, o + 2, mapFn.@call(thisArg, @undefined, o + 2));
-                        @putByValDirect(arr, o + 3, mapFn.@call(thisArg, @undefined, o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, @undefined, o));
-                }
-            }
-
-            else {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
-                        @putByValDirect(arr, o + 1, mapFn.@call(thisArg, arrayLike[o + 1], o + 1));
-                        @putByValDirect(arr, o + 2, mapFn.@call(thisArg, arrayLike[o + 2], o + 2));
-                        @putByValDirect(arr, o + 3, mapFn.@call(thisArg, arrayLike[o + 3], o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
-                }
-            }
-        }
-    }
-
-    return (arr.length = len, arr);
-    // @bun patch
+    return (arr.length = offset, arr);
 }
+
 
 function isArray(array)
 {
@@ -281,7 +330,7 @@ async function defaultAsyncFromAsyncIterator(iterator, mapFn, thisArg)
 {
     "use strict";
 
-    // !bun patch
+    
     const extended = this !== @Array && @isConstructor(this);
 
     let offset = 0;
@@ -321,7 +370,7 @@ async function defaultAsyncFromAsyncIterator(iterator, mapFn, thisArg)
     }
 
     return (arr.length = offset, arr);
-    // @bun patch
+    
 }
 
 @linkTimeConstant
@@ -332,142 +381,149 @@ async function defaultAsyncFromAsyncArrayLike(asyncItems, mapFn, thisArg)
 
     var arrayLike = @toObject(asyncItems, "Array.fromAsync requires an array-like object - not null or undefined");
 
-    // !bun patch
+    
     const len = @toLength(arrayLike.length);
+    const fast = @bun_isLengthObject(arrayLike);
     const extended = this !== @Array && @isConstructor(this);
     const arr = extended ? new this(len) : @newArrayWithSize(len);
 
-    let fast = true;
-    const unrollable = len <= 2 ** 30;
-
-    if (@isArray(arrayLike)) fast = false;
-    else if (@isProxyObject(arrayLike)) fast = false;
-    else if (@isTypedArrayView(arrayLike)) fast = false;
-
-    else {
-        // @isNaturalObject would be useful
-        if (@Object.prototype !== @Object.@getPrototypeOf(arrayLike)) fast = false;
-
-        else {
-            // needs @objectAllKeysCount(obj)
-            const keys = @Object.@getOwnPropertyNames(arrayLike);
-            if (1 !== keys.length || keys[0] !== 'length') fast = false;
-        }
-    }
-
     if (mapFn === @undefined) {
-        if (fast) {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, @undefined);
-
-            else {
-                const unrolled = len & ~3;
-
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, @undefined);
-                    @putByValDirect(arr, o + 1, @undefined);
-                    @putByValDirect(arr, o + 2, @undefined);
-                    @putByValDirect(arr, o + 3, @undefined);
-                }
-
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, @undefined);
-            }
-        }
-
-        else {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
-
-            else {
-                const unrolled = len & ~3;
-
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, await arrayLike[o]);
-                    @putByValDirect(arr, o + 1, await arrayLike[o + 1]);
-                    @putByValDirect(arr, o + 2, await arrayLike[o + 2]);
-                    @putByValDirect(arr, o + 3, await arrayLike[o + 3]);
-                }
-
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
-            }
-        }
+        if (fast) @bun_arrayFillUndefined(arr, len);
+        else await @bun_async_arrayCopyFrom(arr, len, arrayLike);
     }
-
+    
     else {
         if (thisArg === @undefined) {
-            if (fast) {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn(@undefined, o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, await mapFn(@undefined, o));
-                        @putByValDirect(arr, o + 1, await mapFn(@undefined, o + 1));
-                        @putByValDirect(arr, o + 2, await mapFn(@undefined, o + 2));
-                        @putByValDirect(arr, o + 3, await mapFn(@undefined, o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn(@undefined, o));
-                }
-            }
-
-            else {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
-                        @putByValDirect(arr, o + 1, await mapFn(await arrayLike[o + 1], o + 1));
-                        @putByValDirect(arr, o + 2, await mapFn(await arrayLike[o + 2], o + 2));
-                        @putByValDirect(arr, o + 3, await mapFn(await arrayLike[o + 3], o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
-                }
-            }
+            if (fast) await @bun_async_arrayFillMapUndefined(arr, len, mapFn);
+            else await @bun_async_arrayCopyFromMap(arr, len, arrayLike, mapFn);
         }
 
         else {
-            if (fast) {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, @undefined, o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, await mapFn.@call(thisArg, @undefined, o));
-                        @putByValDirect(arr, o + 1, await mapFn.@call(thisArg, @undefined, o + 1));
-                        @putByValDirect(arr, o + 2, await mapFn.@call(thisArg, @undefined, o + 2));
-                        @putByValDirect(arr, o + 3, await mapFn.@call(thisArg, @undefined, o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, @undefined, o));
-                }
-            }
-
-            else {
-                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
-
-                else {
-                    const unrolled = len & ~3;
-
-                    for (let o = 0; o < unrolled; o += 4) {
-                        @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
-                        @putByValDirect(arr, o + 1, await mapFn.@call(thisArg, await arrayLike[o + 1], o + 1));
-                        @putByValDirect(arr, o + 2, await mapFn.@call(thisArg, await arrayLike[o + 2], o + 2));
-                        @putByValDirect(arr, o + 3, await mapFn.@call(thisArg, await arrayLike[o + 3], o + 3));
-                    }
-
-                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
-                }
-            }
+            if (fast) await @bun_async_arrayFillMapUndefinedThis(arr, len, mapFn, thisArg);
+            else await @bun_async_arrayCopyFromMapThis(arr, len, arrayLike, mapFn, thisArg);
         }
     }
 
     return (arr.length = len, arr);
-    // @bun patch
+    
 }
+
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+async function bun_async_arrayCopyFrom(arr, len, src) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, await src[o]);
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, await src[o]);
+            @putByValDirect(arr, o + 1, await src[o + 1]);
+            @putByValDirect(arr, o + 2, await src[o + 2]);
+            @putByValDirect(arr, o + 3, await src[o + 3]);
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await src[o]);
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+async function bun_async_arrayFillMapUndefined(arr, len, map) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, await map(@undefined, o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, await map(@undefined, o));
+            @putByValDirect(arr, o + 1, await map(@undefined, o + 1));
+            @putByValDirect(arr, o + 2, await map(@undefined, o + 2));
+            @putByValDirect(arr, o + 3, await map(@undefined, o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await map(@undefined, o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+async function bun_async_arrayFillMapUndefinedThis(arr, len, map, thisArg) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, await map.@call(thisArg, @undefined, o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, await map.@call(thisArg, @undefined, o));
+            @putByValDirect(arr, o + 1, await map.@call(thisArg, @undefined, o + 1));
+            @putByValDirect(arr, o + 2, await map.@call(thisArg, @undefined, o + 2));
+            @putByValDirect(arr, o + 3, await map.@call(thisArg, @undefined, o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await map.@call(thisArg, @undefined, o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+async function bun_async_arrayCopyFromMap(arr, len, src, map) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, await map(await src[o], o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, await map(await src[o], o));
+            @putByValDirect(arr, o + 1, await map(await src[o + 1], o + 1));
+            @putByValDirect(arr, o + 2, await map(await src[o + 2], o + 2));
+            @putByValDirect(arr, o + 3, await map(await src[o + 3], o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await map(await src[o], o));
+    }
+}
+
+@linkTimeConstant
+@visibility=PrivateRecursive
+async function bun_async_arrayCopyFromMapThis(arr, len, src, map, thisArg) {
+    "use strict";
+    const unrollable = len <= 2 ** 30;
+
+    if (!unrollable)
+        for (let o = 0; o < len; o++) @putByValDirect(arr, o, await map.@call(thisArg, await src[o], o));
+
+    else {
+        const unrolled = len & ~3;
+
+        for (let o = 0; o < unrolled; o += 4) {
+            @putByValDirect(arr, o, await map.@call(thisArg, await src[o], o));
+            @putByValDirect(arr, o + 1, await map.@call(thisArg, await src[o + 1], o + 1));
+            @putByValDirect(arr, o + 2, await map.@call(thisArg, await src[o + 2], o + 2));
+            @putByValDirect(arr, o + 3, await map.@call(thisArg, await src[o + 3], o + 3));
+        }
+
+        for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await map.@call(thisArg, await src[o], o));
+    }
+}
+
 
 function fromAsync(asyncItems  /*, mapFn, thisArg */)
 {

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -130,58 +130,132 @@ function from(items /*, mapFn, thisArg */)
     const len = @toLength(arrayLike.length);
     const extended = this !== @Array && @isConstructor(this);
     const arr = extended ? new this(len) : @newArrayWithSize(len);
-    
+
+    let fast = true;
     const unrollable = len <= 2 ** 30;
 
-    if (mapFn === @undefined) {
-        if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+    if (@isArray(arrayLike)) fast = false;
+    else if (@isProxyObject(arrayLike)) fast = false;
+    else if (@isTypedArrayView(arrayLike)) fast = false;
+
+    else {
+        // @isNaturalObject would be useful
+        if (@Object.prototype !== @Object.@getPrototypeOf(arrayLike)) fast = false;
 
         else {
-            const unrolled = len & ~3;
+            // needs @objectAllKeysCount(obj)
+            const keys = @Object.@getOwnPropertyNames(arrayLike);
+            // can hoist === 'length' check with early return on length
+            if (1 !== keys.length || keys[0] !== 'length') fast = false;
+        }
+    }
 
-            for (let o = 0; o < unrolled; o += 4) {
-                @putByValDirect(arr, o, arrayLike[o]);
-                @putByValDirect(arr, o + 1, arrayLike[o + 1]);
-                @putByValDirect(arr, o + 2, arrayLike[o + 2]);
-                @putByValDirect(arr, o + 3, arrayLike[o + 3]);
+    if (mapFn === @undefined) {
+        if (fast) {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, @undefined);
+
+            else {
+                const unrolled = len & ~3;
+
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, @undefined);
+                    @putByValDirect(arr, o + 1, @undefined);
+                    @putByValDirect(arr, o + 2, @undefined);
+                    @putByValDirect(arr, o + 3, @undefined);
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, @undefined);
             }
+        }
 
-            for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+        else {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+
+            else {
+                const unrolled = len & ~3;
+    
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, arrayLike[o]);
+                    @putByValDirect(arr, o + 1, arrayLike[o + 1]);
+                    @putByValDirect(arr, o + 2, arrayLike[o + 2]);
+                    @putByValDirect(arr, o + 3, arrayLike[o + 3]);
+                }
+    
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, arrayLike[o]);
+            }
         }
     }
 
     else {
         if (thisArg === @undefined) {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
+            if (fast) {
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn(@undefined, o));
+
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, mapFn(@undefined, o));
+                        @putByValDirect(arr, o + 1, mapFn(@undefined, o + 1));
+                        @putByValDirect(arr, o + 2, mapFn(@undefined, o + 2));
+                        @putByValDirect(arr, o + 3, mapFn(@undefined, o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn(@undefined, o));
+                }
+            }
 
             else {
-                const unrolled = len & ~3;
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
 
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, mapFn(arrayLike[o], o));
-                    @putByValDirect(arr, o + 1, mapFn(arrayLike[o + 1], o + 1));
-                    @putByValDirect(arr, o + 2, mapFn(arrayLike[o + 2], o + 2));
-                    @putByValDirect(arr, o + 3, mapFn(arrayLike[o + 3], o + 3));
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, mapFn(arrayLike[o], o));
+                        @putByValDirect(arr, o + 1, mapFn(arrayLike[o + 1], o + 1));
+                        @putByValDirect(arr, o + 2, mapFn(arrayLike[o + 2], o + 2));
+                        @putByValDirect(arr, o + 3, mapFn(arrayLike[o + 3], o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
                 }
-
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn(arrayLike[o], o));
             }
         }
 
         else {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
+            if (fast) {
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, @undefined, o));
+
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, mapFn.@call(thisArg, @undefined, o));
+                        @putByValDirect(arr, o + 1, mapFn.@call(thisArg, @undefined, o + 1));
+                        @putByValDirect(arr, o + 2, mapFn.@call(thisArg, @undefined, o + 2));
+                        @putByValDirect(arr, o + 3, mapFn.@call(thisArg, @undefined, o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, @undefined, o));
+                }
+            }
 
             else {
-                const unrolled = len & ~3;
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
 
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
-                    @putByValDirect(arr, o + 1, mapFn.@call(thisArg, arrayLike[o + 1], o + 1));
-                    @putByValDirect(arr, o + 2, mapFn.@call(thisArg, arrayLike[o + 2], o + 2));
-                    @putByValDirect(arr, o + 3, mapFn.@call(thisArg, arrayLike[o + 3], o + 3));
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
+                        @putByValDirect(arr, o + 1, mapFn.@call(thisArg, arrayLike[o + 1], o + 1));
+                        @putByValDirect(arr, o + 2, mapFn.@call(thisArg, arrayLike[o + 2], o + 2));
+                        @putByValDirect(arr, o + 3, mapFn.@call(thisArg, arrayLike[o + 3], o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
                 }
-
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, mapFn.@call(thisArg, arrayLike[o], o));
             }
         }
     }
@@ -247,6 +321,7 @@ async function defaultAsyncFromAsyncIterator(iterator, mapFn, thisArg)
     }
 
     return (arr.length = offset, arr);
+    // @bun patch
 }
 
 @linkTimeConstant
@@ -262,57 +337,130 @@ async function defaultAsyncFromAsyncArrayLike(asyncItems, mapFn, thisArg)
     const extended = this !== @Array && @isConstructor(this);
     const arr = extended ? new this(len) : @newArrayWithSize(len);
 
+    let fast = true;
     const unrollable = len <= 2 ** 30;
 
-    if (mapFn === @undefined) {
-        if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
+    if (@isArray(arrayLike)) fast = false;
+    else if (@isProxyObject(arrayLike)) fast = false;
+    else if (@isTypedArrayView(arrayLike)) fast = false;
+
+    else {
+        // @isNaturalObject would be useful
+        if (@Object.prototype !== @Object.@getPrototypeOf(arrayLike)) fast = false;
 
         else {
-            const unrolled = len & ~3;
+            // needs @objectAllKeysCount(obj)
+            const keys = @Object.@getOwnPropertyNames(arrayLike);
+            if (1 !== keys.length || keys[0] !== 'length') fast = false;
+        }
+    }
 
-            for (let o = 0; o < unrolled; o += 4) {
-                @putByValDirect(arr, o, await arrayLike[o]);
-                @putByValDirect(arr, o + 1, await arrayLike[o + 1]);
-                @putByValDirect(arr, o + 2, await arrayLike[o + 2]);
-                @putByValDirect(arr, o + 3, await arrayLike[o + 3]);
+    if (mapFn === @undefined) {
+        if (fast) {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, @undefined);
+
+            else {
+                const unrolled = len & ~3;
+
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, @undefined);
+                    @putByValDirect(arr, o + 1, @undefined);
+                    @putByValDirect(arr, o + 2, @undefined);
+                    @putByValDirect(arr, o + 3, @undefined);
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, @undefined);
             }
+        }
 
-            for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
+        else {
+            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
+
+            else {
+                const unrolled = len & ~3;
+
+                for (let o = 0; o < unrolled; o += 4) {
+                    @putByValDirect(arr, o, await arrayLike[o]);
+                    @putByValDirect(arr, o + 1, await arrayLike[o + 1]);
+                    @putByValDirect(arr, o + 2, await arrayLike[o + 2]);
+                    @putByValDirect(arr, o + 3, await arrayLike[o + 3]);
+                }
+
+                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await arrayLike[o]);
+            }
         }
     }
 
     else {
         if (thisArg === @undefined) {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
+            if (fast) {
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn(@undefined, o));
+
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, await mapFn(@undefined, o));
+                        @putByValDirect(arr, o + 1, await mapFn(@undefined, o + 1));
+                        @putByValDirect(arr, o + 2, await mapFn(@undefined, o + 2));
+                        @putByValDirect(arr, o + 3, await mapFn(@undefined, o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn(@undefined, o));
+                }
+            }
 
             else {
-                const unrolled = len & ~3;
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
 
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
-                    @putByValDirect(arr, o + 1, await mapFn(await arrayLike[o + 1], o + 1));
-                    @putByValDirect(arr, o + 2, await mapFn(await arrayLike[o + 2], o + 2));
-                    @putByValDirect(arr, o + 3, await mapFn(await arrayLike[o + 3], o + 3));
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
+                        @putByValDirect(arr, o + 1, await mapFn(await arrayLike[o + 1], o + 1));
+                        @putByValDirect(arr, o + 2, await mapFn(await arrayLike[o + 2], o + 2));
+                        @putByValDirect(arr, o + 3, await mapFn(await arrayLike[o + 3], o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
                 }
-
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn(await arrayLike[o], o));
             }
         }
 
         else {
-            if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
-   
-            else {
-                const unrolled = len & ~3;
-   
-                for (let o = 0; o < unrolled; o += 4) {
-                    @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
-                    @putByValDirect(arr, o + 1, await mapFn.@call(thisArg, await arrayLike[o + 1], o + 1));
-                    @putByValDirect(arr, o + 2, await mapFn.@call(thisArg, await arrayLike[o + 2], o + 2));
-                    @putByValDirect(arr, o + 3, await mapFn.@call(thisArg, await arrayLike[o + 3], o + 3));
-                }
+            if (fast) {
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, @undefined, o));
 
-                for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, await mapFn.@call(thisArg, @undefined, o));
+                        @putByValDirect(arr, o + 1, await mapFn.@call(thisArg, @undefined, o + 1));
+                        @putByValDirect(arr, o + 2, await mapFn.@call(thisArg, @undefined, o + 2));
+                        @putByValDirect(arr, o + 3, await mapFn.@call(thisArg, @undefined, o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, @undefined, o));
+                }
+            }
+
+            else {
+                if (!unrollable) for (let o = 0; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+
+                else {
+                    const unrolled = len & ~3;
+
+                    for (let o = 0; o < unrolled; o += 4) {
+                        @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+                        @putByValDirect(arr, o + 1, await mapFn.@call(thisArg, await arrayLike[o + 1], o + 1));
+                        @putByValDirect(arr, o + 2, await mapFn.@call(thisArg, await arrayLike[o + 2], o + 2));
+                        @putByValDirect(arr, o + 3, await mapFn.@call(thisArg, await arrayLike[o + 3], o + 3));
+                    }
+
+                    for (let o = unrolled; o < len; o++) @putByValDirect(arr, o, await mapFn.@call(thisArg, await arrayLike[o], o));
+                }
             }
         }
     }


### PR DESCRIPTION
passes 262 webkit tests (`Tools/Scripts/test262-runner --release`, build first)
todo: check cpu cycles and instructions count (needs bun build for @mitata/counters)

patch: https://gist.github.com/evanwashere/17778413aba8b1eec1adfe5c6ef04a69

before
```js
------------------------------------------------------- -------------------------------
Array.of(512)                              1.58 µs/iter   1.61 µs   1.63 µs ▁▃▆▇▅▂▂▄█▆▂
Array.of(4096)                            10.23 µs/iter  10.23 µs  10.28 µs ▅▃▃▅██▅▁▁▁▃
Array.of(32768)                           87.47 µs/iter  92.46 µs 110.21 µs ▁█▄▂▁▁▁▃▁▁▁
Array.of(65536)                          154.52 µs/iter 156.46 µs 170.75 µs ▁█▇▇▄▃▂▁▁▁▁

------------------------------------------------------- -------------------------------
Array.from(arr 512)                      196.79 ns/iter 199.10 ns 224.52 ns ▂▅█▇▄▂▁▁▁▁▁
Array.from(arr 4096)                     732.59 ns/iter 734.55 ns 835.02 ns ▁▅█▂▁▁▁▁▁▁▁
Array.from(arr 32768)                      5.88 µs/iter   5.90 µs   5.93 µs ▂▂▂▅▄▄█▄▅▄▂
Array.from(arr 65536)                     11.11 µs/iter  11.65 µs  11.69 µs █▂▁▁▁▁▁▁▁▃█

------------------------------------------------------- -------------------------------
Array.fromAsync(arr 512)                 131.26 ns/iter 131.90 ns 245.42 ns ▂█▄▂▁▁▁▁▁▁▁
Array.fromAsync(arr 4096)                 10.04 µs/iter  11.88 µs  13.33 µs ▄▃█▄▃▁▁▂▄▃▂
Array.fromAsync(arr 32768)                 9.71 µs/iter  10.25 µs  13.33 µs ▅██▆▅▂▁▃▂▁▃
Array.fromAsync(arr 65536)                 9.97 µs/iter  11.83 µs  13.00 µs ▇██▅▂▄▁▂▄▇▂

------------------------------------------------------- -------------------------------
Array.from(512)                           47.93 µs/iter  74.00 µs  76.25 µs █▃▁▁▁▁▁▂▃▆█
Array.from(4096)                          54.00 µs/iter  82.88 µs  87.17 µs ▆▃▂▂▁▁▁▁▃█▃
Array.from(32768)                        105.18 µs/iter 160.21 µs 181.71 µs █▃▁▁▁▁▂▂▂▃▃
Array.from(65536)                        184.21 µs/iter 218.63 µs 239.04 µs ▆▃▁▃▁▂▁▂█▄▃

------------------------------------------------------- -------------------------------
Array.from(512, () => 1)                   8.46 µs/iter  10.50 µs  12.62 µs ▆█▅▃▁▁▁▅▂▁▂
Array.from(4096, () => 1)                 25.36 µs/iter  27.08 µs  29.75 µs ██▃▃▆▆█▆▃▃▃
Array.from(32768, () => 1)               125.75 µs/iter 128.83 µs 133.63 µs ▄▂▄█▂▄▄▄▁▅▂
Array.from(65536, () => 1)               238.31 µs/iter 246.00 µs 253.54 µs ▅█▅▅▅▁▃▆▃▅▃

------------------------------------------------------- -------------------------------
Array.from(iterator 512)                  67.29 µs/iter  97.17 µs 112.63 µs █▅▂▁▁▁▁▄▅▅▃
Array.from(iterator 4096)                141.72 µs/iter 165.42 µs 184.96 µs ▅▅▃▁▁▁▂▄█▄▂
Array.from(iterator 32768)               250.42 µs/iter 248.21 µs 438.42 µs ▃▃▇█▃▂▁▂▁▁▃
Array.from(iterator 65536)               375.99 µs/iter 378.46 µs 730.96 µs ▄▅█▅▁▁▁▁▁▁▂

------------------------------------------------------- -------------------------------
Array.fromAsync(iterator 512)            485.39 µs/iter  87.29 µs   4.85 ms █▁▁▁▁▁▁▁▁▁▁
Array.fromAsync(iterator 4096)           573.32 µs/iter 579.96 µs 610.75 µs ▂▃▃▄█▅▃▂▂▁▁
Array.fromAsync(iterator 32768)            4.28 ms/iter   4.29 ms   4.42 ms ▂▅▇█▃▂▂▂▁▁▁
Array.fromAsync(iterator 65536)            8.50 ms/iter   8.52 ms   8.70 ms ▁▁▃█▇▃▁▁▁▁▂

------------------------------------------------------- -------------------------------
Array.from(iterator 512, () => 1)          2.62 µs/iter   2.60 µs   3.11 µs █▂▁▁▁▁▁▁▁▁▁
Array.from(iterator 4096, () => 1)        18.68 µs/iter  18.61 µs  18.88 µs ▂█▄▄▁▁▁▁▁▁▂
Array.from(iterator 32768, () => 1)      168.15 µs/iter 169.92 µs 182.17 µs ▁▁▁▂▃▂█▃▂▁▁
Array.from(iterator 65536, () => 1)      306.85 µs/iter 311.50 µs 324.46 µs ▁▁▁▂▃▆█▅▃▂▁

------------------------------------------------------- -------------------------------
Array.fromAsync(iterator 512, () => 1)   108.26 µs/iter 110.75 µs 131.71 µs ▁▂█▃▂▂▂▁▁▁▁
Array.fromAsync(iterator 4096, () => 1)  753.81 µs/iter 760.75 µs 788.00 µs ▂▂▂▃█▇▅▃▂▂▁
Array.fromAsync(iterator 32768, () => 1)   5.69 ms/iter   5.70 ms   5.79 ms ▂▅███▄▂▂▂▂▁
Array.fromAsync(iterator 65536, () => 1)  11.34 ms/iter  11.36 ms  11.70 ms ▃█▆▃▁▂▁▁▁▁▁
```

after
```js
------------------------------------------------------- -------------------------------
Array.of(512)                              1.45 µs/iter   1.49 µs   1.50 µs ▁▁▅▇▂▂▂▁▂█▃
Array.of(4096)                             9.17 µs/iter   9.18 µs   9.23 µs ▂▁▁▄█▅▇▁▅▁▂
Array.of(32768)                           73.83 µs/iter  74.01 µs  74.57 µs █▃▃▁▆▁▆▃▁▁▃
Array.of(65536)                          135.46 µs/iter 135.25 µs 151.42 µs ▁▁▂█▂▂▁▁▁▁▁

------------------------------------------------------- -------------------------------
Array.from(arr 512)                      189.49 ns/iter 190.93 ns 218.66 ns ▁▇█▄▂▁▁▁▁▁▁
Array.from(arr 4096)                     731.71 ns/iter 733.40 ns 852.39 ns ▂█▄▁▁▁▁▁▁▁▁
Array.from(arr 32768)                      5.80 µs/iter   5.80 µs   5.87 µs ▂▅█▅▃▂▁▂▁▁▂
Array.from(arr 65536)                     11.62 µs/iter  11.63 µs  11.64 µs ▂▁▂▂▂▁▄█▄▂▂

------------------------------------------------------- -------------------------------
Array.fromAsync(arr 512)                 130.52 ns/iter 129.05 ns 244.67 ns ▃█▄▁▁▁▁▁▁▁▁
Array.fromAsync(arr 4096)                 10.44 µs/iter  11.29 µs  13.46 µs ▅▄▄█▇▇▇▄▂▄▂
Array.fromAsync(arr 32768)                 9.06 µs/iter  10.08 µs  11.50 µs ▂█▂█▅▂▃▂▃▃▃
Array.fromAsync(arr 65536)                 9.32 µs/iter   9.79 µs  12.75 µs ▅▇█▃▃▃▃▁▁▁▃

------------------------------------------------------- -------------------------------
Array.from(512)                           25.83 µs/iter  53.87 µs  70.96 µs █▂▁▁▁▁▁▁▁▃▂
Array.from(4096)                          61.17 µs/iter  78.58 µs  84.42 µs ▅▂▂▁▁▁▂▃█▆▄
Array.from(32768)                         74.08 µs/iter 124.71 µs 138.42 µs █▆▂▁▁▁▁▁▂▂▅
Array.from(65536)                        107.06 µs/iter 153.58 µs 180.58 µs █▄▂▂▂▁▁▂▃▁▂

------------------------------------------------------- -------------------------------
Array.from(512, () => 1)                   7.76 µs/iter   8.08 µs  10.08 µs ▃▃▂█▃▅▁▂▃▁▂
Array.from(4096, () => 1)                 25.13 µs/iter  26.92 µs  31.58 µs █▂▂▂▄▇▄▂▄▁▂
Array.from(32768, () => 1)               116.97 µs/iter 120.29 µs 126.92 µs ▆██▅▃▃▃▅▃▁▃
Array.from(65536, () => 1)               219.08 µs/iter 222.67 µs 231.50 µs ▂█▁█▁▇▄▄▁▂▂

------------------------------------------------------- -------------------------------
Array.from(iterator 512)                  64.47 µs/iter  88.71 µs 102.08 µs ▅▅▂▂▃▁▁▃█▄▂
Array.from(iterator 4096)                102.48 µs/iter 123.96 µs 146.96 µs █▂▂▃▁▁▃▇▄▁▄
Array.from(iterator 32768)               226.90 µs/iter 232.63 µs 398.33 µs ▅▇▃██▁▁▁▁▁▅
Array.from(iterator 65536)               297.57 µs/iter 322.12 µs 350.96 µs ▇▅▂▁▁▂█▇▃▁▃

------------------------------------------------------- -------------------------------
Array.fromAsync(iterator 512)            430.12 µs/iter  84.46 µs   4.66 ms █▁▁▁▁▁▁▁▁▁▁
Array.fromAsync(iterator 4096)           559.06 µs/iter 563.71 µs 588.04 µs ▁▁▃██▅▃▃▂▁▁
Array.fromAsync(iterator 32768)            4.10 ms/iter   4.11 ms   4.18 ms ▁▂▆█▅▂▁▁▁▁▁
Array.fromAsync(iterator 65536)            8.15 ms/iter   8.19 ms   8.31 ms ▃█▅▂▂▃▃▁▂▁▁

------------------------------------------------------- -------------------------------
Array.from(iterator 512, () => 1)          2.17 µs/iter   2.13 µs   2.87 µs █▁▁▁▁▁▁▁▁▁▁
Array.from(iterator 4096, () => 1)        15.02 µs/iter  15.00 µs  15.12 µs ██▆▁▃▁▁▁▁▁▃
Array.from(iterator 32768, () => 1)      134.04 µs/iter 136.75 µs 150.92 µs ▁▁▂█▃▆▃▂▂▁▁
Array.from(iterator 65536, () => 1)      241.85 µs/iter 244.96 µs 258.21 µs ▁▁▂▂█▄▅▃▂▁▁

------------------------------------------------------- -------------------------------
Array.fromAsync(iterator 512, () => 1)   107.68 µs/iter 109.46 µs 130.00 µs ▁▂█▃▂▂▁▁▁▁▁
Array.fromAsync(iterator 4096, () => 1)  754.21 µs/iter 760.25 µs 791.71 µs ▁▁▁▃█▅▄▃▂▁▁
Array.fromAsync(iterator 32768, () => 1)   5.64 ms/iter   5.64 ms   5.70 ms ▁▆██▄▃▃▂▁▁▁
Array.fromAsync(iterator 65536, () => 1)  11.22 ms/iter  11.23 ms  11.39 ms ▂▆█▄▃▁▁▁▁▁▁
```